### PR TITLE
[dtacheck] Update arson-parse to latest commit

### DIFF
--- a/crates/dtacheck/Cargo.toml
+++ b/crates/dtacheck/Cargo.toml
@@ -7,6 +7,10 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-arson = { git = "https://github.com/hmxmilohax/arson", version = "0.1.0", rev = "c0c102c86f3734d41623b2fd4bfc78bf74302500" }
 clap = { version = "4.4.12", features = ["derive"] }
-codespan-reporting = "0.11.1"
+
+[dependencies.arson-parse]
+version = "0.1.0"
+git = "https://github.com/hmxmilohax/arson"
+rev = "7b65f20fc2f409d1bfedb4b0bdfbe581c8e6e969"
+features = ["reporting"]

--- a/crates/dtacheck/src/main.rs
+++ b/crates/dtacheck/src/main.rs
@@ -2,8 +2,7 @@ use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
 
-use arson::parse::lexer;
-use arson::parse::parser;
+use arson_parse::reporting as codespan_reporting;
 use clap::Parser as ClapParser;
 use codespan_reporting::files::SimpleFiles;
 use codespan_reporting::term;
@@ -12,7 +11,6 @@ use codespan_reporting::term::termcolor::StandardStream;
 use codespan_reporting::term::Chars;
 use dtacheck::linter::lint_file;
 use dtacheck::linter::Function;
-use dtacheck::linter::Lint;
 
 #[derive(ClapParser)]
 struct Args {
@@ -53,8 +51,7 @@ fn main() {
     let mut files = SimpleFiles::new();
     let file_id = files.add(args.file.to_str().unwrap(), &data);
 
-    let tokens = lexer::lex(&data);
-    let (ast, diagnostics) = match parser::parse(tokens) {
+    let (ast, diagnostics) = match arson_parse::parse_text(&data) {
         Ok(ast) => (ast, Vec::new()),
         Err(errors) => (Vec::new(), errors),
     };


### PR DESCRIPTION
Many parsing and diagnostic improvements.

- Errors are now sorted by position and error code, instead of being in an unspecified order.
- Added some additional diagnostics, fixed many cases where errors were not detected or reported properly, and tweaked many error messages to be more informative.
- Validation checks done when reaching the end of the file were unintentionally performed per array nesting, and would result in duplicate diagnostics for outer-nested errors.
- Parsing no longer bails out upon errors in the preprocessing step, so all errors related to parsing are displayed at once.
- Block comment handling no longer tokenizes its contents, and will no longer miss block comment ends that are preceded by delimiters for other tokens.