### PR TITLE
dtacheck: Bump arson-parse to v0.3.0, and exclude comments from being parsed

### DIFF
--- a/crates/dtacheck/Cargo.toml
+++ b/crates/dtacheck/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 clap = { version = "4.4.12", features = ["derive"] }
 
 [dependencies.arson-parse]
-version = "0.2.0"
+version = "0.3.0"
 git = "https://github.com/hmxmilohax/arson"
-tag = "v0.2.0"
+tag = "v0.3.0"
 features = ["reporting"]

--- a/crates/dtacheck/src/linter.rs
+++ b/crates/dtacheck/src/linter.rs
@@ -120,11 +120,11 @@ impl Function {
             return (self, depth);
         };
 
-        let ExpressionValue::Symbol(sym) = node.value else {
+        let ExpressionValue::Symbol(ref sym) = node.value else {
             return (self, depth);
         };
 
-        let Some(func) = self.children.get(sym) else {
+        let Some(func) = self.children.get(sym.as_ref()) else {
             return (self, depth);
         };
 
@@ -166,12 +166,10 @@ fn lint_fn_args(
 fn generate_function_name(stmt: &[Expression]) -> String {
     let list: Vec<&str> = stmt
         .iter()
-        .map(|x| match x.value {
-            ExpressionValue::Symbol(sym) => Some(sym),
+        .map_while(|x| match x.value {
+            ExpressionValue::Symbol(ref sym) => Some(sym.as_ref()),
             _ => None,
         })
-        .take_while(Option::is_some)
-        .map(|x| x.unwrap())
         .collect();
 
     list.join(" ")
@@ -202,7 +200,7 @@ fn lint_switch_fallthrough(
         return;
     }
 
-    let ExpressionValue::Symbol(sym) = stmt[0].value else {
+    let ExpressionValue::Symbol(ref sym) = stmt[0].value else {
         return;
     };
 

--- a/crates/dtacheck/src/main.rs
+++ b/crates/dtacheck/src/main.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 use std::path::PathBuf;
 
 use arson_parse::reporting as codespan_reporting;
+use arson_parse::ParseOptions;
 use clap::Parser as ClapParser;
 use codespan_reporting::files::SimpleFiles;
 use codespan_reporting::term;
@@ -51,7 +52,10 @@ fn main() {
     let mut files = SimpleFiles::new();
     let file_id = files.add(args.file.to_str().unwrap(), &data);
 
-    let (ast, diagnostics) = match arson_parse::parse_text(&data) {
+    let parse_options = ParseOptions {
+        include_comments: false,
+    };
+    let (ast, diagnostics) = match arson_parse::parse_text(&data, parse_options) {
         Ok(ast) => (ast, Vec::new()),
         Err(error) => (Vec::new(), error.diagnostics),
     };


### PR DESCRIPTION
This fixes problems with comments being handled as actual values, as such as the following example:

```
{if_else $value
   ; We only want to do_thing under specific circumstances
   {do_thing}
   {do_other_thing}
}
```

This currently causes an error diagnostic to be generated, due to there reportedly being 3 values inside the `if_else` due to the inclusion of the comment.

Closes #9.